### PR TITLE
feat: filtros de estágio e tipo + correção de navegação no login

### DIFF
--- a/firebase/functions/src/orders/handlers/getOrdersList.ts
+++ b/firebase/functions/src/orders/handlers/getOrdersList.ts
@@ -10,14 +10,18 @@ import { OrderType } from "../types/documents";
 import { orderTypes } from "../shared/constants";
 import { findOrdersByOrderType } from "../repositories/orderRepository";
 import { getAuthenticatedUser } from "../../shared/auth";
+import {
+  StartupStageFilter,
+  StartupsSearchFilters,
+} from "../../startup/constants/startupStageFilters";
 
 /*
- * Retorna de de ordens com lazy loading
+ * Retorna lista de ordens com lazy loading e filtro opcional de estágio de startup
  */
 export const getOrdersList = onCall(async (req) => {
   const { uid } = getAuthenticatedUser(req);
 
-  let { orderType, offset, limit } = req.data as GetOrdersRequestDTO;
+  let { orderType, offset, limit, stage } = req.data as GetOrdersRequestDTO;
   orderType = normalizeString(orderType).toLowerCase() as OrderType;
 
   if (!orderType || !orderTypes.includes(orderType)) {
@@ -41,7 +45,18 @@ export const getOrdersList = onCall(async (req) => {
     );
   }
 
-  const orders = await findOrdersByOrderType(orderType, uid, offset, limit);
+  const stageFilter: StartupStageFilter =
+    stage && StartupsSearchFilters.includes(stage as StartupStageFilter)
+      ? (stage as StartupStageFilter)
+      : "all";
+
+  const orders = await findOrdersByOrderType(
+    orderType,
+    uid,
+    offset,
+    limit,
+    stageFilter,
+  );
 
   return {
     orders,

--- a/firebase/functions/src/orders/repositories/orderRepository.ts
+++ b/firebase/functions/src/orders/repositories/orderRepository.ts
@@ -12,6 +12,10 @@ import { OrderListDTO, OrderRegisterDTO } from "../types/dtos";
 import { InvestmentDocument, WalletDocument } from "../../user/types/documents";
 import { StartupResumeDTO } from "../../startup/types/dtos";
 import { formatCurrency } from "../../shared/formatters";
+import {
+  StartupStageFilter,
+  StartupsSearchFilters,
+} from "../../startup/constants/startupStageFilters";
 
 const getInvestmentsCollection = (uid: string) =>
   database.collection("investments").doc(uid).collection("startups");
@@ -29,13 +33,34 @@ export const findOrdersByOrderType = async (
   userUId: string,
   offset: number,
   limit: number,
+  stageFilter: StartupStageFilter = "all",
 ): Promise<OrderListDTO[]> => {
-  const snapshot = await ordersCollection
-    .where("type", "==", orderType)
-    .orderBy("createdAt", "desc")
-    .offset(offset)
-    .limit(limit)
-    .get();
+  // Pré-filtra IDs de startups pelo estágio, quando solicitado
+  let allowedStartupIds: string[] | null = null;
+  if (stageFilter !== "all" && StartupsSearchFilters.includes(stageFilter)) {
+    const stageSnapshot = await startupsCollection
+      .where("stage", "==", stageFilter)
+      .select()
+      .get();
+    allowedStartupIds = stageSnapshot.docs.map((doc) => doc.id);
+    if (allowedStartupIds.length === 0) return [];
+  }
+
+  const snapshot =
+    allowedStartupIds !== null
+      ? await ordersCollection
+          .where("type", "==", orderType)
+          .where("startupId", "in", allowedStartupIds)
+          .orderBy("createdAt", "desc")
+          .offset(offset)
+          .limit(limit)
+          .get()
+      : await ordersCollection
+          .where("type", "==", orderType)
+          .orderBy("createdAt", "desc")
+          .offset(offset)
+          .limit(limit)
+          .get();
 
   const orders = snapshot.docs.map((doc) => ({
     id: doc.id,
@@ -49,7 +74,7 @@ export const findOrdersByOrderType = async (
   const startupsSnapshot = startupIds.length
     ? await startupsCollection
         .where(admin.firestore.FieldPath.documentId(), "in", startupIds)
-        .select("name")
+        .select("name", "stage")
         .get()
     : null;
 
@@ -92,7 +117,7 @@ export const findUserOrders = async (
   const startupsSnapshot = startupIds.length
     ? await startupsCollection
         .where(admin.firestore.FieldPath.documentId(), "in", startupIds)
-        .select("name")
+        .select("name", "stage")
         .get()
     : null;
 

--- a/firebase/functions/src/orders/types/dtos.ts
+++ b/firebase/functions/src/orders/types/dtos.ts
@@ -32,4 +32,5 @@ export interface GetOrdersRequestDTO {
   orderType: OrderType;
   offset: number;
   limit: number;
+  stage?: string;
 }

--- a/firebase/functions/src/startup/repositories/startupsRepository.ts
+++ b/firebase/functions/src/startup/repositories/startupsRepository.ts
@@ -124,7 +124,7 @@ export const findStartupsResumes = async (
   uid: string,
 ): Promise<StartupResumeDTO[]> => {
   const snapshot = await startupsCollection
-    .select("name", "currentTokenPriceCents", "initialTokenPriceCents")
+    .select("name", "currentTokenPriceCents", "initialTokenPriceCents", "stage")
     .get();
   const investedIds = await getInvestedStartupIds(uid);
 
@@ -136,6 +136,7 @@ export const findStartupsResumes = async (
       currentTokenPriceCents: startup.currentTokenPriceCents,
       initialTokenPriceCents: startup.initialTokenPriceCents,
       isInvestor: investedIds.has(doc.id),
+      stage: startup.stage,
     };
   }) satisfies StartupResumeDTO[];
 };

--- a/firebase/functions/src/startup/types/dtos.ts
+++ b/firebase/functions/src/startup/types/dtos.ts
@@ -38,6 +38,7 @@ export interface StartupResumeDTO {
   isInvestor: boolean;
   currentTokenPriceCents: number;
   initialTokenPriceCents: number;
+  stage?: StartupStage;
 }
 
 export interface StartupTokenInfoDTO {

--- a/firebase/functions/src/transaction/repositories/transactionsRepository.ts
+++ b/firebase/functions/src/transaction/repositories/transactionsRepository.ts
@@ -40,6 +40,7 @@ export const findUserTransactions = async (
           currentTokenPriceCents: 0,
           initialTokenPriceCents: 0,
           isInvestor: false,
+          stage: undefined,
         },
       } satisfies StartupTransactionListDTO;
     }

--- a/firebase/functions/src/user/repositories/usersRepository.ts
+++ b/firebase/functions/src/user/repositories/usersRepository.ts
@@ -167,6 +167,7 @@ export const getInvestments = async (
             isInvestor: true,
             currentTokenPriceCents: startup.currentTokenPriceCents,
             initialTokenPriceCents: startup.initialTokenPriceCents,
+            stage: startup.stage,
           }
         : {
             id: data.startupId,

--- a/frontend/mescla_invest/lib/formatters/number_limit_formatter.dart
+++ b/frontend/mescla_invest/lib/formatters/number_limit_formatter.dart
@@ -1,0 +1,29 @@
+import 'package:flutter/services.dart';
+
+class NumberLimitFormatter extends TextInputFormatter {
+  final int maxValue;
+
+  NumberLimitFormatter({this.maxValue = 9999});
+
+  @override
+  TextEditingValue formatEditUpdate(
+    TextEditingValue oldValue,
+    TextEditingValue newValue,
+  ) {
+    if (newValue.text.isEmpty) return newValue;
+
+    final digitsOnly = newValue.text.replaceAll(RegExp(r'[^0-9]'), '');
+    final intValue = int.tryParse(digitsOnly);
+
+    if (intValue == null) return oldValue;
+
+    if (intValue > maxValue) return oldValue;
+
+    final corrected = intValue.toString();
+
+    return newValue.copyWith(
+      text: corrected,
+      selection: TextSelection.collapsed(offset: corrected.length),
+    );
+  }
+}

--- a/frontend/mescla_invest/lib/models/startup/startup_model.dart
+++ b/frontend/mescla_invest/lib/models/startup/startup_model.dart
@@ -21,7 +21,21 @@ enum StartupStage {
   }
 }
 
-enum StartupStageFilter { nova, em_operacao, em_expansao, all }
+enum StartupStageFilter {
+  all,
+  nova,
+  em_operacao,
+  em_expansao;
+
+  String get label {
+    return switch (this) {
+      StartupStageFilter.all => "Todas",
+      StartupStageFilter.nova => "Nova",
+      StartupStageFilter.em_operacao => "Em operação",
+      StartupStageFilter.em_expansao => "Em expansão",
+    };
+  }
+}
 
 // StartupResumeDTO — resumo mínimo retornado em listas, ordens e transações
 class StartupResumeDTO {
@@ -42,12 +56,15 @@ class StartupResumeDTO {
         100;
   }
 
+  final StartupStage? stage;
+
   const StartupResumeDTO({
     required this.id,
     required this.name,
     required this.currentTokenPriceCents,
     required this.initialTokenPriceCents,
     this.isInvestor = false,
+    this.stage,
   });
 
   factory StartupResumeDTO.fromMap(Map<String, dynamic> rawMap) {
@@ -59,6 +76,9 @@ class StartupResumeDTO {
       currentTokenPriceCents: map['currentTokenPriceCents'] ?? 0,
       initialTokenPriceCents: map['initialTokenPriceCents'] ?? 0,
       isInvestor: map['isInvestor'] == true,
+      stage: map['stage'] != null
+          ? StartupStage.values.byName(map['stage'] as String)
+          : null,
     );
   }
 }

--- a/frontend/mescla_invest/lib/models/user/transaction_model.dart
+++ b/frontend/mescla_invest/lib/models/user/transaction_model.dart
@@ -8,6 +8,22 @@ import 'package:mescla_invest/models/startup/startup_model.dart';
 
 enum TransactionType { investment, funds, trade }
 
+enum TransactionTypeFilter {
+  all,
+  funds,
+  investment,
+  trade;
+
+  String get label {
+    return switch (this) {
+      all => "Todos",
+      funds => "Depósito",
+      investment => "Compra Direta",
+      trade => "Balcão",
+    };
+  }
+}
+
 /*
  * Modelo base de transação.
  * Todas as transações possuem id, tipo, valor em centavos, data

--- a/frontend/mescla_invest/lib/screens/app/marketplace/create_order_screen.dart
+++ b/frontend/mescla_invest/lib/screens/app/marketplace/create_order_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mescla_invest/constants/colors.dart';
+import 'package:mescla_invest/formatters/number_limit_formatter.dart';
 import 'package:mescla_invest/formatters/str_formaters.dart';
 import 'package:mescla_invest/models/order_model.dart';
 import 'package:mescla_invest/models/startup/startup_model.dart';
@@ -96,6 +97,14 @@ class _CreateOrderScreenState extends State<CreateOrderScreen> {
   Future<void> _submitOrder() async {
     setState(() => _isSubmitting = true);
 
+    if (_selectedStartup == null) {
+      return showSnackbar(
+        msg: "Selecione uma startup para continuar!",
+        context: context,
+        isError: true,
+      );
+    }
+
     try {
       await OrderService.registerOrder(
         startupId: _selectedStartup!.id,
@@ -144,7 +153,10 @@ class _CreateOrderScreenState extends State<CreateOrderScreen> {
 
                     return Expanded(
                       child: GestureDetector(
-                        onTap: () => setState(() => _orderType = t),
+                        onTap: () => setState(() {
+                          _selectedStartup = null;
+                          _orderType = t;
+                        }),
                         child: Container(
                           padding: const EdgeInsets.symmetric(vertical: 12),
                           decoration: BoxDecoration(
@@ -279,6 +291,7 @@ class _CreateOrderScreenState extends State<CreateOrderScreen> {
                         ),
                         inputFormatters: [
                           FilteringTextInputFormatter.digitsOnly,
+                          NumberLimitFormatter(),
                         ],
                         onChanged: (_) => setState(() {}),
                       ),
@@ -343,6 +356,7 @@ class _CreateOrderScreenState extends State<CreateOrderScreen> {
                   ),
                   inputFormatters: [
                     FilteringTextInputFormatter.allow(RegExp(r'[\d,.]')),
+                    NumberLimitFormatter(),
                   ],
                   onChanged: (_) => setState(() {}),
                 ),
@@ -387,9 +401,7 @@ class _CreateOrderScreenState extends State<CreateOrderScreen> {
                           ),
                         ),
                         Text(
-                          _total > 0
-                              ? 'R\$ ${_total.toStringAsFixed(2).replaceAll('.', ',')}'
-                              : '—',
+                          _total > 0 ? formatCurrency(_total) : '—',
                           style: const TextStyle(
                             color: AppColors.verdeMescla,
                             fontWeight: FontWeight.bold,

--- a/frontend/mescla_invest/lib/screens/app/marketplace/market_screen.dart
+++ b/frontend/mescla_invest/lib/screens/app/marketplace/market_screen.dart
@@ -4,6 +4,7 @@
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/constants/colors.dart';
 import 'package:mescla_invest/models/order_model.dart';
+import 'package:mescla_invest/models/startup/startup_model.dart';
 import 'package:mescla_invest/screens/app/marketplace/create_order_screen.dart';
 import 'package:mescla_invest/screens/app/wallet/order_card.dart';
 import 'package:mescla_invest/services/order_service.dart';
@@ -18,6 +19,7 @@ class MarketScreen extends StatefulWidget {
 
 class _MarketScreenState extends State<MarketScreen> {
   OrderTypeFilter _activeTab = OrderTypeFilter.buy;
+  StartupStageFilter _selectedStage = StartupStageFilter.all;
 
   // Listas de ordens carregadas do backend
   List<OrderModel> _buyOrders = [];
@@ -38,8 +40,18 @@ class _MarketScreenState extends State<MarketScreen> {
 
     try {
       final results = await Future.wait([
-        OrderService.getOrders(orderType: OrderType.buy, offset: 0, limit: 10),
-        OrderService.getOrders(orderType: OrderType.sell, offset: 0, limit: 10),
+        OrderService.getOrders(
+          orderType: OrderType.buy,
+          offset: 0,
+          limit: 10,
+          stageFilter: _selectedStage,
+        ),
+        OrderService.getOrders(
+          orderType: OrderType.sell,
+          offset: 0,
+          limit: 10,
+          stageFilter: _selectedStage,
+        ),
         OrderService.getUserOrders(),
       ]);
 
@@ -69,6 +81,43 @@ class _MarketScreenState extends State<MarketScreen> {
     if (result == true && mounted) {
       await _fetchOrders();
     }
+  }
+
+  Widget _buildFilterTags() {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: StartupStageFilter.values.map((stage) {
+          final isSelected = _selectedStage == stage;
+          return GestureDetector(
+            onTap: () {
+              if (_selectedStage != stage) {
+                setState(() => _selectedStage = stage);
+                _fetchOrders();
+              }
+            },
+            child: Container(
+              margin: const EdgeInsets.only(right: 8),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? AppColors.verdeMescla
+                    : AppColors.campoEscuro,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                stage.label,
+                style: TextStyle(
+                  color: isSelected ? Colors.black : Colors.white70,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
   }
 
   Widget _buildOrderList() {
@@ -170,7 +219,15 @@ class _MarketScreenState extends State<MarketScreen> {
                 ),
               ),
 
-              const SizedBox(height: 16),
+              const SizedBox(height: 12),
+
+              // Filtros de estágio
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16),
+                child: _buildFilterTags(),
+              ),
+
+              const SizedBox(height: 12),
 
               // Label da aba
               Padding(

--- a/frontend/mescla_invest/lib/screens/app/startup/buy_tokens_sheet.dart
+++ b/frontend/mescla_invest/lib/screens/app/startup/buy_tokens_sheet.dart
@@ -6,6 +6,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mescla_invest/constants/colors.dart';
+import 'package:mescla_invest/formatters/number_limit_formatter.dart';
 import 'package:mescla_invest/formatters/str_formaters.dart';
 import 'package:mescla_invest/models/startup/startup_model.dart';
 import 'package:mescla_invest/services/user_service.dart';
@@ -173,7 +174,10 @@ class _BuyTokensSheetState extends State<BuyTokensSheet> {
                       border: InputBorder.none,
                       contentPadding: EdgeInsets.symmetric(vertical: 12),
                     ),
-                    inputFormatters: [FilteringTextInputFormatter.digitsOnly],
+                    inputFormatters: [
+                      FilteringTextInputFormatter.digitsOnly,
+                      NumberLimitFormatter(),
+                    ],
                     onChanged: (_) => setState(() {}),
                   ),
                 ),

--- a/frontend/mescla_invest/lib/screens/app/startup/catalog_screen.dart
+++ b/frontend/mescla_invest/lib/screens/app/startup/catalog_screen.dart
@@ -3,6 +3,8 @@
  * RA: 25000636 
  */
 
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/formatters/str_formaters.dart';
 import 'package:mescla_invest/models/startup/startup_model.dart';
@@ -25,9 +27,11 @@ class _CatalogScreenState extends State<CatalogScreen> {
   bool _isLoading = true;
   bool _isMoreLoading = false;
   bool _hasMore = true;
-
-  int _offset = 0;
   final int _limit = 10;
+  int _offset = 0;
+  int _fetchToken = 0;
+
+  Timer? _debounce;
 
   StartupStageFilter _selectedStage = StartupStageFilter.all;
   String _searchName = "";
@@ -43,6 +47,7 @@ class _CatalogScreenState extends State<CatalogScreen> {
   void dispose() {
     _scrollController.dispose();
     _searchController.dispose();
+    _debounce?.cancel();
     super.dispose();
   }
 
@@ -57,6 +62,8 @@ class _CatalogScreenState extends State<CatalogScreen> {
   }
 
   Future<void> _fetchStartups({bool reset = false}) async {
+    final token = ++_fetchToken; // incrementa a cada chamada
+
     if (reset) {
       setState(() {
         _offset = 0;
@@ -77,21 +84,21 @@ class _CatalogScreenState extends State<CatalogScreen> {
         nameFilter: _searchName,
       );
 
+      // Se um fetch mais novo já foi iniciado, descarta este resultado
+      if (token != _fetchToken) return;
+
       if (mounted) {
         setState(() {
           _startups.addAll(newStartups);
           _offset = _startups.length;
-
-          if (newStartups.length < _limit) {
-            _hasMore = false;
-          }
+          if (newStartups.length < _limit) _hasMore = false;
         });
       }
     } catch (err, stack) {
-      if (mounted) {
-        handleException(err: err, stack: stack, context: context);
-      }
+      if (token != _fetchToken) return;
+      if (mounted) handleException(err: err, stack: stack, context: context);
     } finally {
+      if (token != _fetchToken) return;
       if (mounted) {
         setState(() {
           _isLoading = false;
@@ -180,9 +187,12 @@ class _CatalogScreenState extends State<CatalogScreen> {
       child: TextField(
         controller: _searchController,
         style: const TextStyle(color: Colors.white),
-        onSubmitted: (value) {
+        onChanged: (value) {
           setState(() => _searchName = value);
-          _fetchStartups(reset: true);
+          _debounce?.cancel();
+          _debounce = Timer(const Duration(milliseconds: 400), () {
+            _fetchStartups(reset: true);
+          });
         },
         decoration: InputDecoration(
           icon: const Icon(Icons.search, color: Colors.white38, size: 20),
@@ -205,28 +215,21 @@ class _CatalogScreenState extends State<CatalogScreen> {
   }
 
   Widget _buildFilterTags() {
-    final Map<String, StartupStageFilter> filters = {
-      'Todas': StartupStageFilter.all,
-      'Nova': StartupStageFilter.nova,
-      'Em Operação': StartupStageFilter.em_operacao,
-      'Em expansão': StartupStageFilter.em_expansao,
-    };
-
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Row(
-        children: filters.entries.map((entry) {
-          bool isSelected = _selectedStage == entry.value;
+        children: StartupStageFilter.values.map((stage) {
+          bool isSelected = _selectedStage == stage;
           return GestureDetector(
             onTap: () {
-              if (_selectedStage != entry.value) {
-                setState(() => _selectedStage = entry.value);
+              if (_selectedStage != stage) {
+                setState(() => _selectedStage = stage);
                 _fetchStartups(reset: true);
               }
             },
             child: Container(
               margin: const EdgeInsets.only(right: 8),
-              padding: const EdgeInsets.symmetric(horizontal: 20, vertical: 10),
+              padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
               decoration: BoxDecoration(
                 color: isSelected
                     ? AppColors.verdeMescla
@@ -234,10 +237,11 @@ class _CatalogScreenState extends State<CatalogScreen> {
                 borderRadius: BorderRadius.circular(20),
               ),
               child: Text(
-                entry.key,
+                stage.label,
                 style: TextStyle(
                   color: isSelected ? Colors.black : Colors.white70,
                   fontWeight: FontWeight.bold,
+                  fontSize: 12,
                 ),
               ),
             ),

--- a/frontend/mescla_invest/lib/screens/app/wallet/history_tab.dart
+++ b/frontend/mescla_invest/lib/screens/app/wallet/history_tab.dart
@@ -4,7 +4,7 @@ import 'package:mescla_invest/formatters/str_formaters.dart';
 import 'package:mescla_invest/models/user/transaction_model.dart';
 import 'package:mescla_invest/screens/app_root.dart';
 
-class HistoryTab extends StatelessWidget {
+class HistoryTab extends StatefulWidget {
   final List<TransactionModel> transactions;
   final bool isLoading;
 
@@ -15,35 +15,103 @@ class HistoryTab extends StatelessWidget {
   });
 
   @override
+  State<HistoryTab> createState() => _HistoryTabState();
+}
+
+class _HistoryTabState extends State<HistoryTab> {
+  TransactionTypeFilter _selectedType = TransactionTypeFilter.all;
+
+  List<TransactionModel> get _filtered {
+    if (_selectedType == TransactionTypeFilter.all) return widget.transactions;
+    return widget.transactions
+        .where((tx) => tx.type.name == _selectedType.name)
+        .toList();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (isLoading) {
+    if (widget.isLoading) {
       return const Center(
         child: CircularProgressIndicator(color: AppColors.verdeMescla),
       );
     }
 
-    if (transactions.isEmpty) {
-      return Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Icon(Icons.receipt_long_outlined, color: Colors.white24, size: 48),
-            const SizedBox(height: 12),
-            Text(
-              "Nenhuma transação registrada.",
-              textAlign: TextAlign.center,
-              style: const TextStyle(color: Colors.white38, fontSize: 14),
-            ),
-          ],
-        ),
-      );
-    }
+    final filtered = _filtered;
 
-    return ListView.builder(
-      physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
-      itemCount: transactions.length,
-      itemBuilder: (_, i) => _TransactionCard(tx: transactions[i]),
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: _buildFilterTags(),
+        ),
+        Expanded(
+          child: filtered.isEmpty
+              ? Center(
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Icon(
+                        Icons.receipt_long_outlined,
+                        color: Colors.white24,
+                        size: 48,
+                      ),
+                      const SizedBox(height: 12),
+                      Text(
+                        'Nenhuma transação encontrada.',
+                        textAlign: TextAlign.center,
+                        style: const TextStyle(
+                          color: Colors.white38,
+                          fontSize: 14,
+                        ),
+                      ),
+                    ],
+                  ),
+                )
+              : ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                  itemCount: filtered.length,
+                  itemBuilder: (_, i) => _TransactionCard(tx: filtered[i]),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFilterTags() {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: TransactionTypeFilter.values.map((type) {
+          final isSelected = _selectedType == type;
+          return GestureDetector(
+            onTap: () {
+              if (_selectedType != type) {
+                setState(() => _selectedType = type);
+              }
+            },
+            child: Container(
+              margin: const EdgeInsets.only(right: 8),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? AppColors.verdeMescla
+                    : AppColors.campoEscuro,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                type.label,
+                style: TextStyle(
+                  color: isSelected ? Colors.black : Colors.white70,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
     );
   }
 }

--- a/frontend/mescla_invest/lib/screens/app/wallet/investments_tab.dart
+++ b/frontend/mescla_invest/lib/screens/app/wallet/investments_tab.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:mescla_invest/constants/colors.dart';
+import 'package:mescla_invest/models/startup/startup_model.dart';
 import 'package:mescla_invest/models/user/investment_model.dart';
 
-class InvestmentsTab extends StatelessWidget {
+class InvestmentsTab extends StatefulWidget {
   final List<InvestmentModel> investments;
   final bool isLoading;
 
@@ -13,18 +14,89 @@ class InvestmentsTab extends StatelessWidget {
   });
 
   @override
+  State<InvestmentsTab> createState() => _InvestmentsTabState();
+}
+
+class _InvestmentsTabState extends State<InvestmentsTab> {
+  StartupStageFilter _selectedStage = StartupStageFilter.all;
+
+  List<InvestmentModel> get _filtered {
+    if (_selectedStage == StartupStageFilter.all) return widget.investments;
+    return widget.investments.where((inv) {
+      return inv.startup.stage?.name == _selectedStage.name;
+    }).toList();
+  }
+
+  @override
   Widget build(BuildContext context) {
-    if (isLoading) {
+    if (widget.isLoading) {
       return const Center(
         child: CircularProgressIndicator(color: AppColors.verdeMescla),
       );
     }
 
-    return ListView.builder(
-      physics: const AlwaysScrollableScrollPhysics(),
-      padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
-      itemCount: investments.length,
-      itemBuilder: (_, i) => _InvestmentCard(investment: investments[i]),
+    final filtered = _filtered;
+
+    return Column(
+      children: [
+        Padding(
+          padding: const EdgeInsets.fromLTRB(16, 12, 16, 0),
+          child: _buildFilterTags(),
+        ),
+        Expanded(
+          child: filtered.isEmpty
+              ? Center(
+                  child: Text(
+                    'Nenhum investimento encontrado.',
+                    style: const TextStyle(color: Colors.white38, fontSize: 14),
+                  ),
+                )
+              : ListView.builder(
+                  physics: const AlwaysScrollableScrollPhysics(),
+                  padding: const EdgeInsets.fromLTRB(16, 12, 16, 24),
+                  itemCount: filtered.length,
+                  itemBuilder: (_, i) =>
+                      _InvestmentCard(investment: filtered[i]),
+                ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildFilterTags() {
+    return SingleChildScrollView(
+      scrollDirection: Axis.horizontal,
+      child: Row(
+        children: StartupStageFilter.values.map((stage) {
+          final isSelected = _selectedStage == stage;
+          return GestureDetector(
+            onTap: () {
+              if (_selectedStage != stage) {
+                setState(() => _selectedStage = stage);
+              }
+            },
+            child: Container(
+              margin: const EdgeInsets.only(right: 8),
+              padding:
+                  const EdgeInsets.symmetric(horizontal: 12, vertical: 8),
+              decoration: BoxDecoration(
+                color: isSelected
+                    ? AppColors.verdeMescla
+                    : AppColors.campoEscuro,
+                borderRadius: BorderRadius.circular(20),
+              ),
+              child: Text(
+                stage.label,
+                style: TextStyle(
+                  color: isSelected ? Colors.black : Colors.white70,
+                  fontWeight: FontWeight.bold,
+                  fontSize: 12,
+                ),
+              ),
+            ),
+          );
+        }).toList(),
+      ),
     );
   }
 }

--- a/frontend/mescla_invest/lib/screens/public/auth/signin.dart
+++ b/frontend/mescla_invest/lib/screens/public/auth/signin.dart
@@ -43,7 +43,7 @@ class _SigninScreenState extends State<SigninScreen> {
   }
 
   void _goToWelcome() {
-    Navigator.of(context).pushNamedAndRemoveUntil('/welcome', (route) => false);
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   Future<void> _loginUsuario() async {

--- a/frontend/mescla_invest/lib/screens/public/auth/signup.dart
+++ b/frontend/mescla_invest/lib/screens/public/auth/signup.dart
@@ -62,7 +62,7 @@ class _SignupScreenState extends State<SignupScreen> {
   }
 
   void _goToWelcome() {
-    Navigator.of(context).pushNamedAndRemoveUntil('/welcome', (route) => false);
+    Navigator.of(context).popUntil((route) => route.isFirst);
   }
 
   Future<void> _cadastrarUsuario() async {

--- a/frontend/mescla_invest/lib/services/order_service.dart
+++ b/frontend/mescla_invest/lib/services/order_service.dart
@@ -5,6 +5,7 @@
 
 import 'package:cloud_functions/cloud_functions.dart';
 import 'package:mescla_invest/models/order_model.dart';
+import 'package:mescla_invest/models/startup/startup_model.dart';
 
 class OrderService {
   // Busca todas as ordens de um tipo
@@ -12,10 +13,17 @@ class OrderService {
     required OrderType orderType,
     required int offset,
     required int limit,
+    StartupStageFilter stageFilter = StartupStageFilter.all,
   }) async {
+    final params = <String, dynamic>{
+      'orderType': orderType.name,
+      'offset': offset,
+      'limit': limit,
+      if (stageFilter != StartupStageFilter.all) 'stage': stageFilter.name,
+    };
     final response = await FirebaseFunctions.instance
         .httpsCallable('getOrdersList')
-        .call({'orderType': orderType.name, 'offset': offset, 'limit': limit});
+        .call(params);
 
     final data = Map<String, dynamic>.from(response.data);
     final List raw = data['orders'] ?? [];

--- a/frontend/mescla_invest/lib/widgets/layout/add_funds_sheet.dart
+++ b/frontend/mescla_invest/lib/widgets/layout/add_funds_sheet.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:mescla_invest/constants/colors.dart';
+import 'package:mescla_invest/formatters/number_limit_formatter.dart';
 import 'package:mescla_invest/services/user_service.dart';
 import 'package:mescla_invest/utils/handle_exception.dart';
 
@@ -105,7 +106,7 @@ class _AddFundsSheetState extends State<AddFundsSheet> {
         ),
         SizedBox(height: 4),
         Text(
-          'Simulação — nenhum valor real será cobrado. Mínimo: R\$ 10,00.',
+          'Mínimo: R\$ 10,00.',
           style: TextStyle(color: Colors.white38, fontSize: 13),
         ),
       ],
@@ -141,7 +142,10 @@ class _AddFundsSheetState extends State<AddFundsSheet> {
           borderSide: BorderSide(color: AppColors.verdeMescla, width: 2),
         ),
       ),
-      inputFormatters: [FilteringTextInputFormatter.allow(RegExp(r'[0-9,.]'))],
+      inputFormatters: [
+        FilteringTextInputFormatter.allow(RegExp(r'[0-9,.]')),
+        NumberLimitFormatter(maxValue: 1_000_000),
+      ],
       onChanged: (_) {
         if (_error != null) setState(() => _error = null);
       },


### PR DESCRIPTION
- Adicionados filtros de estágio de startup no mercado (com chamada ao backend)
- Adicionados filtros de estágio na aba de investimentos da carteira
- Adicionados filtros de tipo de transação no histórico da carteira
- Backend: stage propagado em StartupResumeDTO (ordens, investimentos, transações)
- Corrigido bug onde voltar do cadastro quebrava o fluxo de login (AppRoot removido da pilha)